### PR TITLE
gallery now updates its gallery items asynchronously

### DIFF
--- a/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryAdapter.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryAdapter.java
@@ -49,6 +49,17 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.ViewHold
   }
 
   /**
+   * Update the scan data and notify the adapter that the data has changed.
+   * This triggers the gallery to redraw.
+   *
+   * @param scans New scan data to set.
+   */
+  public void setScanData(List<Scan> scans) {
+    this.scans = scans;
+    notifyDataSetChanged();
+  }
+
+  /**
    * Simple ViewHolder object that initialises thumbImage and thumbTitle to references.
    * of the ViewHolder's ImageView and TextView
    */

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryDetailFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryDetailFragment.java
@@ -13,6 +13,8 @@ import android.widget.TextView;
 import com.swinburne.irtsa.irtsa.R;
 import com.swinburne.irtsa.irtsa.model.Scan;
 
+import java.util.List;
+
 /**
  * A simple {@link Fragment} subclass.
  */
@@ -52,6 +54,5 @@ public class GalleryDetailFragment extends Fragment {
     name.setText("Name: " + scan.name);
     description = v.findViewById(R.id.galleryDetailDescription);
     description.setText("Description: " + scan.description);
-
   }
 }

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryFragment.java
@@ -1,5 +1,6 @@
 package com.swinburne.irtsa.irtsa.gallery;
 
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
@@ -14,6 +15,10 @@ import android.view.ViewGroup;
 import com.swinburne.irtsa.irtsa.R;
 import com.swinburne.irtsa.irtsa.ToolbarSetter;
 import com.swinburne.irtsa.irtsa.model.Scan;
+import com.swinburne.irtsa.irtsa.model.ScanAccessObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import io.reactivex.functions.Consumer;
 
@@ -23,10 +28,6 @@ import io.reactivex.functions.Consumer;
 public class GalleryFragment extends Fragment {
   private RecyclerView recyclerView;
   private GalleryAdapter adapter;
-
-  public void refreshGallery() {
-    adapter.refreshScans();
-  }
 
   @Override
   public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -75,5 +76,43 @@ public class GalleryFragment extends Fragment {
   public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
     super.onCreateOptionsMenu(menu, inflater);
     inflater.inflate(R.menu.gallery_toolbar, menu);
+  }
+
+  public void refreshGallery() {
+    RefreshGalleryItemsTask galleryRefreshTask = new RefreshGalleryItemsTask();
+    galleryRefreshTask.execute();
+  }
+
+  /**
+   * Task that asynchronously fetches all scans and provides this data to the adapter.
+   * Performed asynchronously to prevent lag when swiping the viewpager.
+   */
+  private class RefreshGalleryItemsTask extends AsyncTask {
+    private List<Scan> scans = new ArrayList<>();
+
+    /**
+     * Get all scans.
+     * Return type is irrelevant here.
+     *
+     * @param objects Data to work with in the background, irrelevant for this implementation.
+     * @return data to return, irrelevant for this implementation.
+     */
+    @Override
+    protected Boolean doInBackground(Object[] objects) {
+      ScanAccessObject scanAccessObject = new ScanAccessObject(getContext());
+      scans =  scanAccessObject.getAllScans();
+      return true;
+    }
+
+    /**
+     * Executes on the main thread and updates the adapter's list of scan items.
+     *
+     * @param o irrelevant in our use case.
+     */
+    @Override
+    protected void onPostExecute(Object o) {
+      super.onPostExecute(o);
+      adapter.setScanData(scans);
+    }
   }
 }


### PR DESCRIPTION
When the viewpager is swiped to the gallery fragment it re-retrieves all scans from the database in case any new scans have been saved.

The retrieval of scans from the DB on viewpager swipe is now done on an async thread, this resolves lag issues when swiping the viewpager.