### PR TITLE
gallery orders scans by created at date

### DIFF
--- a/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryAdapter.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryAdapter.java
@@ -15,6 +15,8 @@ import com.swinburne.irtsa.irtsa.model.ScanInterface;
 import io.reactivex.Observable;
 import io.reactivex.subjects.PublishSubject;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -38,14 +40,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.ViewHold
   public GalleryAdapter(Context context) {
     scanAccessObject = new ScanAccessObject(context);
     scans = scanAccessObject.getAllScans();
-  }
-
-  /**
-   * Update the list of scans with any recently added scans.
-   */
-  public void refreshScans() {
-    scans = scanAccessObject.getAllScans();
-    notifyDataSetChanged();
+    Collections.sort(scans, new SortByCreatedAt());
   }
 
   /**
@@ -123,5 +118,18 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.ViewHold
    */
   public Observable<Scan> getGalleryClick() {
     return onClickGalleryItem;
+  }
+
+  /**
+   * Comparator to sort scans by their created at date.
+   */
+  private class SortByCreatedAt implements Comparator<Scan> {
+    @Override
+    public int compare(Scan scan, Scan t1) {
+      if (scan.createdAt == null || t1.createdAt == null) {
+        return 0;
+      }
+      return scan.createdAt.compareTo(t1.createdAt);
+    }
   }
 }

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryFragment.java
@@ -13,14 +13,14 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.swinburne.irtsa.irtsa.R;
-import com.swinburne.irtsa.irtsa.ToolbarSetter;
 import com.swinburne.irtsa.irtsa.model.Scan;
 import com.swinburne.irtsa.irtsa.model.ScanAccessObject;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import io.reactivex.functions.Consumer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Fragment that displays the saved scan gallery.
@@ -100,7 +100,13 @@ public class GalleryFragment extends Fragment {
     @Override
     protected Boolean doInBackground(Object[] objects) {
       ScanAccessObject scanAccessObject = new ScanAccessObject(getContext());
-      scans =  scanAccessObject.getAllScans();
+      scans = scanAccessObject.getAllScans();
+      Collections.sort(scans, (scan, scanToCompare) -> {
+        if (scan.createdAt == null || scanToCompare.createdAt == null) {
+          return 0;
+        }
+        return scan.createdAt.compareTo(scanToCompare.createdAt);
+      });
       return true;
     }
 

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/model/Scan.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/model/Scan.java
@@ -6,6 +6,9 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 import java.io.ByteArrayOutputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * Scan model object to represent a saved scan.
@@ -17,6 +20,7 @@ public class Scan implements Parcelable {
   public Bitmap image;
   public String description;
   public String name;
+  public Date createdAt;
 
   public Scan(){}
 
@@ -31,6 +35,10 @@ public class Scan implements Parcelable {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     image.compress(Bitmap.CompressFormat.PNG, 100, stream);
     return stream.toByteArray();
+  }
+
+  static DateFormat getDateFormat() {
+    return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
   }
 
   private void setImage(byte[] image) {

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/model/Scan.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/model/Scan.java
@@ -29,6 +29,7 @@ public class Scan implements Parcelable {
     this.setImage(in.createByteArray());
     this.description = in.readString();
     this.name = in.readString();
+    this.createdAt = new Date(in.readLong());
   }
 
   private byte[] getImage() {
@@ -66,6 +67,7 @@ public class Scan implements Parcelable {
     parcel.writeByteArray(this.getImage());
     parcel.writeString(this.description);
     parcel.writeString(this.name);
+    parcel.writeLong(this.createdAt.getTime());
   }
 
 }

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/model/ScanAccessObject.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/model/ScanAccessObject.java
@@ -7,9 +7,13 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.util.Log;
 
 import java.io.ByteArrayOutputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -54,6 +58,16 @@ public class ScanAccessObject extends SQLiteOpenHelper implements ScanInterface 
       scan.name = resultCursor.getString(resultCursor.getColumnIndex(COLUMN_NAME));
       scan.description = resultCursor.getString(resultCursor.getColumnIndex(COLUMN_DESCRIPTION));
 
+      try {
+        scan.createdAt = Scan.getDateFormat().parse(
+                resultCursor.getString(resultCursor.getColumnIndex(COLUMN_CREATED_AT)));
+      } catch (ParseException e) {
+        Log.e("ScanAccessObject",
+                "(" + scan.id + ", " + scan.name + ") Unable to parse created at date: "
+                        + e.getMessage());
+      }
+
+
       byte[] image = resultCursor.getBlob(resultCursor.getColumnIndex(COLUMN_IMAGE));
       scan.image = BitmapFactory.decodeByteArray(image, 0, image.length);
 
@@ -75,6 +89,7 @@ public class ScanAccessObject extends SQLiteOpenHelper implements ScanInterface 
     data.put(COLUMN_NAME, scan.name);
     data.put(COLUMN_DESCRIPTION, scan.description);
     data.put(COLUMN_IMAGE, imageBlob);
+    data.put(COLUMN_CREATED_AT, Scan.getDateFormat().format(new Date()));
 
     SQLiteDatabase db = this.getWritableDatabase();
     long rowInserted = db.insert(TABLE_SCAN, null, data);

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/model/ScanInterface.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/model/ScanInterface.java
@@ -11,13 +11,15 @@ public interface ScanInterface {
   String COLUMN_DESCRIPTION = "Description";
   String COLUMN_IMAGE = "Image";
   String COLUMN_ID = "Id"; // Unique Identifier
+  String COLUMN_CREATED_AT = "Created_At";
 
   String CREATE_SCAN_TABLE = "CREATE TABLE " + TABLE_SCAN
       + "("
       + "Id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,"
       + "Name VARCHAR(255) NOT NULL,"
       + "Description VARCHAR(255) NOT NULL,"
-      + "Image varbinary(1000) NOT NULL"
+      + "Image varbinary(1000) NOT NULL,"
+      + "Created_At TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL"
       + ")";
 
   /**


### PR DESCRIPTION
Scans now have a created at date that is stored when they are saved to the database. The gallery fragment sorts scans based on this date (newest -> oldest)

**If the app is not completely reinstalled before using this version of the code, scans may not be sorted correctly**