### PR TITLE
Handle orientation change

### DIFF
--- a/app/src/main/java/com/swinburne/irtsa/irtsa/MainActivity.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/MainActivity.java
@@ -144,6 +144,12 @@ public class MainActivity extends AppCompatActivity {
     }
   }
 
+  /**
+   * Save the name of the currently visible fragment so it can be compared if the app must be
+   * recreated.
+   *
+   * @param outState The bundle that will store data when the activity is destroyed.
+   */
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/MainActivity.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/MainActivity.java
@@ -21,6 +21,11 @@ public class MainActivity extends AppCompatActivity {
   private ViewPager pager;
   private ViewPagerAdapter pagerAdapter;
   private TabLayout tabLayout;
+  private String previouslyFocusedFragment;
+
+  public String getPreviouslyFocusedFragment() {
+    return previouslyFocusedFragment;
+  }
 
   /**
    * When the activity is created initialise the tabs and view pager.
@@ -31,6 +36,9 @@ public class MainActivity extends AppCompatActivity {
   protected void onCreate(Bundle savedInstanceState) {
     setTheme(R.style.AppThemeLight);
     super.onCreate(savedInstanceState);
+    if (savedInstanceState != null) {
+      previouslyFocusedFragment = savedInstanceState.getString("previouslyFocusedFragment");
+    }
     setContentView(R.layout.activity_main);
     tabLayout = findViewById(R.id.tabLayout);
     pager = findViewById(R.id.viewPager);
@@ -85,7 +93,7 @@ public class MainActivity extends AppCompatActivity {
    *
    * @param position position of the currently selected view pager tab.
    */
-  private void invalidateFragmentMenus(int position) {
+  public void invalidateFragmentMenus(int position) {
     Fragment visibleFragment = pagerAdapter.getCurrentlyVisibleFragment(position);
     for (int i = 0; i < pagerAdapter.getCount(); i++) {
       for (Fragment fragment : pagerAdapter.getNestedFragments(i)) {
@@ -107,7 +115,7 @@ public class MainActivity extends AppCompatActivity {
     if (currentChildFragments.size() == 1) {
       finish();
     } else {
-      pagerAdapter.getItem(pager.getCurrentItem())
+      pagerAdapter.getFragmentMap().get(pager.getCurrentItem())
               .getChildFragmentManager().popBackStackImmediate();
     }
 
@@ -134,5 +142,12 @@ public class MainActivity extends AppCompatActivity {
     public void onPageScrollStateChanged(int state) {
 
     }
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putString("previouslyFocusedFragment",
+            pagerAdapter.getCurrentlyVisibleFragment(pager.getCurrentItem()).getClass().getCanonicalName());
   }
 }

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/ViewPagerAdapter.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/ViewPagerAdapter.java
@@ -2,7 +2,11 @@ package com.swinburne.irtsa.irtsa;
 
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.app.FragmentTransaction;
+import android.view.View;
+import android.view.ViewGroup;
 
 import com.swinburne.irtsa.irtsa.containers.GalleryContainerFragment;
 import com.swinburne.irtsa.irtsa.containers.ScanContainerFragment;
@@ -15,17 +19,21 @@ import java.util.Map;
 /**
  * This adapter specifies the two container Fragments the ViewPager will display.
  */
-public class ViewPagerAdapter extends FragmentStatePagerAdapter {
+public class ViewPagerAdapter extends FragmentPagerAdapter {
   private Map<Integer, Fragment> fragmentMap;
 
   /**
-  * Constructor that calls the superclass.
-  *
-  * @param fm FragmentManager required to initialise the superclass.
-  */
+   * Constructor that calls the superclass.
+   *
+   * @param fm FragmentManager required to initialise the superclass.
+   */
   public ViewPagerAdapter(FragmentManager fm) {
     super(fm);
     fragmentMap = new HashMap<>();
+  }
+
+  public Map<Integer, Fragment> getFragmentMap() {
+    return fragmentMap;
   }
 
   /**
@@ -37,26 +45,20 @@ public class ViewPagerAdapter extends FragmentStatePagerAdapter {
    */
   @Override
   public Fragment getItem(int position) {
-    final Fragment result;
-
-    if (fragmentMap.containsKey(position)) {
-      return fragmentMap.get(position);
-    } else {
-      switch (position) {
-        case 0:
-          result = new ScanContainerFragment();
-          break;
-        case 1:
-          result = new GalleryContainerFragment();
-          break;
-        default:
-          result = null;
-          break;
-      }
+    switch (position) {
+      case 0:
+        return new ScanContainerFragment();
+      case 1:
+        return new GalleryContainerFragment();
+      default:
+        return null;
     }
-    fragmentMap.put(position, result);
-    return result;
   }
+
+//  @Override
+//  public boolean isViewFromObject(View view, Object fragment) {
+//    return ((Fragment) fragment).getView() == view;
+//  }
 
   /**
    * Returns the amount of ViewPager tabs.
@@ -66,6 +68,13 @@ public class ViewPagerAdapter extends FragmentStatePagerAdapter {
   @Override
   public int getCount() {
     return 2;
+  }
+
+  @Override
+  public Object instantiateItem(ViewGroup container, int position) {
+    Fragment createdFragment = (Fragment) super.instantiateItem(container, position);
+    fragmentMap.put(position, createdFragment);
+    return createdFragment;
   }
 
   /**
@@ -95,19 +104,24 @@ public class ViewPagerAdapter extends FragmentStatePagerAdapter {
    * @return A List containing the currently visible fragment, and any fragments on the backstack.
    */
   public List<Fragment> getNestedFragments(int position) {
-    Fragment fragmentContainer = fragmentMap.get(position);
-    FragmentManager containerChildFm = fragmentContainer.getChildFragmentManager();
     List<Fragment> nestedFragments = new ArrayList<>();
+    if (fragmentMap.containsKey(position)) {
+      Fragment fragmentContainer = fragmentMap.get(position);
+      FragmentManager containerChildFm = fragmentContainer.getChildFragmentManager();
 
-    // Add any fragments not added to the backstack (currently visible fragment in container)
-    for (Fragment fragment : containerChildFm.getFragments()) {
-      nestedFragments.add(fragment);
-    }
 
-    // Add any fragments present in the container's child fragment manager backstack.
-    for (int i = 0; i < containerChildFm.getBackStackEntryCount(); i++) {
-      String name = containerChildFm.getBackStackEntryAt(i).getName();
-      nestedFragments.add(containerChildFm.findFragmentByTag(name));
+      // Add any fragments not added to the backstack (currently visible fragment in container)
+      for (Fragment fragment : containerChildFm.getFragments()) {
+        nestedFragments.add(fragment);
+      }
+
+      // Add any fragments present in the container's child fragment manager backstack.
+      for (int i = 0; i < containerChildFm.getBackStackEntryCount(); i++) {
+        String name = containerChildFm.getBackStackEntryAt(i).getName();
+        nestedFragments.add(containerChildFm.findFragmentByTag(name));
+      }
+    } else {
+      System.out.println("Unable to get nested fragments, fragment map does not contain key");
     }
 
     return nestedFragments;
@@ -121,13 +135,17 @@ public class ViewPagerAdapter extends FragmentStatePagerAdapter {
    * @return The currently displayed fragment
    */
   public Fragment getCurrentlyVisibleFragment(int position) {
-    Fragment fragmentContainer = fragmentMap.get(position);
-    FragmentManager containerChildFm = fragmentContainer.getChildFragmentManager();
+    if (fragmentMap.containsKey(position)) {
+      Fragment fragmentContainer = fragmentMap.get(position);
+      FragmentManager containerChildFm = fragmentContainer.getChildFragmentManager();
 
-    // The container should only contain one fragment (the rest will be on the backstack).
-    for (Fragment fragment : containerChildFm.getFragments()) {
-      System.out.println(fragment.getTag());
-      return fragment;
+      // The container should only contain one fragment (the rest will be on the backstack).
+      for (Fragment fragment : containerChildFm.getFragments()) {
+        System.out.println(fragment.getTag());
+        return fragment;
+      }
+    } else {
+      System.out.println("Unable to get currently visible fragment, fragment map does not contain key");
     }
 
     return null;

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/containers/GalleryContainerFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/containers/GalleryContainerFragment.java
@@ -1,12 +1,14 @@
 package com.swinburne.irtsa.irtsa.containers;
 
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.swinburne.irtsa.irtsa.MainActivity;
 import com.swinburne.irtsa.irtsa.R;
 import com.swinburne.irtsa.irtsa.gallery.GalleryFragment;
 
@@ -30,11 +32,13 @@ public class GalleryContainerFragment extends Fragment {
    * Immediately load the GalleryFragment once this container Fragment becomes visible.
    */
   @Override
-  public void onStart() {
-    super.onStart();
-    GalleryFragment galleryFragment = new GalleryFragment();
-    FragmentTransaction transaction = getChildFragmentManager().beginTransaction();
+  public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    if (savedInstanceState == null) {
+      GalleryFragment galleryFragment = new GalleryFragment();
+      FragmentTransaction transaction = getChildFragmentManager().beginTransaction();
 
-    transaction.replace(R.id.galleryContainer, galleryFragment, "GalleryFragment").commit();
+      transaction.replace(R.id.galleryContainer, galleryFragment, "GalleryFragment").commit();
+    }
   }
 }

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/containers/ScanContainerFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/containers/ScanContainerFragment.java
@@ -1,6 +1,7 @@
 package com.swinburne.irtsa.irtsa.containers;
 
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
@@ -30,10 +31,12 @@ public class ScanContainerFragment extends Fragment {
    * Immediately load the StartScanFragment once this container Fragment becomes visible.
    */
   @Override
-  public void onStart() {
-    super.onStart();
-    StartScanFragment startScanFragment = new StartScanFragment();
-    FragmentTransaction transaction = getChildFragmentManager().beginTransaction();
-    transaction.replace(R.id.scanContainer, startScanFragment, "StartScanFragment").commit();
+  public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    if (savedInstanceState == null) {
+      StartScanFragment startScanFragment = new StartScanFragment();
+      FragmentTransaction transaction = getChildFragmentManager().beginTransaction();
+      transaction.replace(R.id.scanContainer, startScanFragment, "StartScanFragment").commit();
+    }
   }
 }

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryDetailFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryDetailFragment.java
@@ -37,6 +37,7 @@ public class GalleryDetailFragment extends Fragment {
   @Override
   public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
     super.onCreateOptionsMenu(menu, inflater);
+    menu.removeItem(R.id.settings);
     inflater.inflate(R.menu.gallery_detail_toolbar, menu);
   }
 

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryDetailFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryDetailFragment.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.swinburne.irtsa.irtsa.MainActivity;
 import com.swinburne.irtsa.irtsa.R;
 import com.swinburne.irtsa.irtsa.model.Scan;
 
@@ -30,14 +31,9 @@ public class GalleryDetailFragment extends Fragment {
   private TextView description;
   private TextView date;
 
-  public GalleryDetailFragment() {
-    setHasOptionsMenu(true);
-  }
-
   @Override
   public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
     super.onCreateOptionsMenu(menu, inflater);
-    menu.removeItem(R.id.settings);
     inflater.inflate(R.menu.gallery_detail_toolbar, menu);
   }
 
@@ -71,6 +67,11 @@ public class GalleryDetailFragment extends Fragment {
       scan = bundle.getParcelable("Scan");
     }
     View v = inflater.inflate(R.layout.fragment_gallery_detail, container, false);
+    if (savedInstanceState != null) {
+      setHasOptionsMenu(((MainActivity)getActivity()).getPreviouslyFocusedFragment().equals(getClass().getCanonicalName()));
+    } else {
+      setHasOptionsMenu(true);
+    }
     initialiseUi(v, scan);
     return v;
   }

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/gallery/GalleryFragment.java
@@ -12,6 +12,7 @@ import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.swinburne.irtsa.irtsa.MainActivity;
 import com.swinburne.irtsa.irtsa.R;
 import com.swinburne.irtsa.irtsa.model.Scan;
 import com.swinburne.irtsa.irtsa.model.ScanAccessObject;
@@ -37,7 +38,12 @@ public class GalleryFragment extends Fragment {
     // Inflate the layout for this fragment
     View v = inflater.inflate(R.layout.fragment_gallery, container, false);
     // Required so the gallery toolbar doesn't display when the app is first launched.
-    setHasOptionsMenu(false);
+    //setHasOptionsMenu(true);
+
+  //  int test = ((MainActivity)getActivity()).getSelectedViewPagerTab();
+    if (savedInstanceState != null) {
+      setHasOptionsMenu(((MainActivity)getActivity()).getPreviouslyFocusedFragment().equals(getClass().getCanonicalName()));
+    }
 
     initialiseUi(v);
 
@@ -101,14 +107,16 @@ public class GalleryFragment extends Fragment {
      */
     @Override
     protected Boolean doInBackground(Object[] objects) {
-      ScanAccessObject scanAccessObject = new ScanAccessObject(getContext());
-      scans = scanAccessObject.getAllScans();
-      Collections.sort(scans, (scan, scanToCompare) -> {
-        if (scan.createdAt == null || scanToCompare.createdAt == null) {
-          return 0;
-        }
-        return scan.createdAt.compareTo(scanToCompare.createdAt);
-      });
+      if (getContext() != null) {
+        ScanAccessObject scanAccessObject = new ScanAccessObject(getContext());
+        scans = scanAccessObject.getAllScans();
+        Collections.sort(scans, (scan, scanToCompare) -> {
+          if (scan.createdAt == null || scanToCompare.createdAt == null) {
+            return 0;
+          }
+          return scan.createdAt.compareTo(scanToCompare.createdAt);
+        });
+      }
       return true;
     }
 
@@ -120,7 +128,7 @@ public class GalleryFragment extends Fragment {
     @Override
     protected void onPostExecute(Object o) {
       super.onPostExecute(o);
-      adapter.setScanData(scans);
+      if (adapter != null) adapter.setScanData(scans);
     }
   }
 }

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/scan/StartScanFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/scan/StartScanFragment.java
@@ -45,11 +45,6 @@ public class StartScanFragment extends Fragment {
     Body body;
   }
 
-//  public StartScanFragment() {
-//    //setHasOptionsMenu(true);
-//  }
-
-
   @Override
   public View onCreateView(LayoutInflater inflater, ViewGroup container,
                            Bundle savedInstanceState) {
@@ -60,6 +55,8 @@ public class StartScanFragment extends Fragment {
 
     if (savedInstanceState != null) {
       setHasOptionsMenu(((MainActivity)getActivity()).getPreviouslyFocusedFragment().equals(getClass().getCanonicalName()));
+    } else {
+      setHasOptionsMenu(true);
     }
 
     return rootView;
@@ -72,12 +69,6 @@ public class StartScanFragment extends Fragment {
   private void initialiseUi(View rootView) {
     Button startScanButton = rootView.findViewById(R.id.startScanButton);
     startScanButton.setOnClickListener(view -> beginScan());
-  }
-
-  @Override
-  public void onResume() {
-    super.onResume();
-    if (isVisible()) setHasOptionsMenu(true);
   }
 
   /**
@@ -107,7 +98,6 @@ public class StartScanFragment extends Fragment {
   @Override
   public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
     super.onCreateOptionsMenu(menu, inflater);
-
     inflater.inflate(R.menu.start_scan_toolbar, menu);
   }
 }

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/scan/StartScanFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/scan/StartScanFragment.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 
+import com.swinburne.irtsa.irtsa.MainActivity;
 import com.swinburne.irtsa.irtsa.R;
 import com.swinburne.irtsa.irtsa.server.Message;
 import com.swinburne.irtsa.irtsa.server.Server;
@@ -44,9 +45,9 @@ public class StartScanFragment extends Fragment {
     Body body;
   }
 
-  public StartScanFragment() {
-    setHasOptionsMenu(true);
-  }
+//  public StartScanFragment() {
+//    //setHasOptionsMenu(true);
+//  }
 
 
   @Override
@@ -57,6 +58,10 @@ public class StartScanFragment extends Fragment {
 
     initialiseUi(rootView);
 
+    if (savedInstanceState != null) {
+      setHasOptionsMenu(((MainActivity)getActivity()).getPreviouslyFocusedFragment().equals(getClass().getCanonicalName()));
+    }
+
     return rootView;
   }
 
@@ -66,12 +71,13 @@ public class StartScanFragment extends Fragment {
    */
   private void initialiseUi(View rootView) {
     Button startScanButton = rootView.findViewById(R.id.startScanButton);
-    startScanButton.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        beginScan();
-      }
-    });
+    startScanButton.setOnClickListener(view -> beginScan());
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    if (isVisible()) setHasOptionsMenu(true);
   }
 
   /**

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/scan/ViewScanFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/scan/ViewScanFragment.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
+import com.swinburne.irtsa.irtsa.MainActivity;
 import com.swinburne.irtsa.irtsa.R;
 
 /**
@@ -17,10 +18,6 @@ import com.swinburne.irtsa.irtsa.R;
  */
 public class ViewScanFragment extends Fragment {
   private ImageView scanImage;
-
-  public ViewScanFragment() {
-    setHasOptionsMenu(true);
-  }
 
   /**
    * When the view scan fragment is opened the icons are changed in the
@@ -59,6 +56,12 @@ public class ViewScanFragment extends Fragment {
                            Bundle savedInstanceState) {
     // Inflate the layout for this fragment
     View v = inflater.inflate(R.layout.fragment_view_scan, container, false);
+
+    if (savedInstanceState != null) {
+      setHasOptionsMenu(((MainActivity)getActivity()).getPreviouslyFocusedFragment().equals(getClass().getCanonicalName()));
+    } else {
+      setHasOptionsMenu(true);
+    }
 
     initialiseUi(v);
 


### PR DESCRIPTION
This branch contains adjustments to the code to support device orientation changes and overall application stability.
- The `ViewPager` used in the app was not properly saving/restoring the fragments being displayed when the device was rotated. This was causing the app to crash if it was rotated or brought out of focus more than a couple of times.

The ViewPager now saves its state properly. Changes to the toolbar code have also been made to ensure it always displays the correct icons. Rotation is also now supported.