### PR TITLE
observers of the server now properly unsubscribe on app recreation

### DIFF
--- a/app/src/main/java/com/swinburne/irtsa/irtsa/scan/ScanProgressFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/scan/ScanProgressFragment.java
@@ -75,6 +75,7 @@ public class ScanProgressFragment extends Fragment {
 
     Server.messages.castToType("scan_progress", ScanProgressMessage.class)
         .takeUntil(Server.messages.ofType("scan_complete"))
+        .takeWhile(event -> getActivity() != null)
         .observeOn(AndroidSchedulers.mainThread())
         .subscribe(message -> {
           Log.i("MESSAGE", "Message received");
@@ -86,6 +87,7 @@ public class ScanProgressFragment extends Fragment {
 
     Server.messages.castToType("scan_complete", ScanCompleteMessage.class)
         .observeOn(AndroidSchedulers.mainThread())
+        .takeWhile(event -> getActivity() != null)
         .subscribe(message -> {
           String imageEncodedToBase64 = message.body.base64EncodedString;
           byte[] decodedImage = Base64.decode(imageEncodedToBase64, Base64.DEFAULT);

--- a/app/src/main/java/com/swinburne/irtsa/irtsa/scan/StartScanFragment.java
+++ b/app/src/main/java/com/swinburne/irtsa/irtsa/scan/StartScanFragment.java
@@ -96,7 +96,9 @@ public class StartScanFragment extends Fragment {
     });
 
     startScanButton.setOnClickListener(view -> beginScan());
+
     Server.status.observeOn(AndroidSchedulers.mainThread())
+            .takeWhile(event -> getActivity() != null)
             .subscribe(connectionStatus -> {
               boolean isConnected = connectionStatus.compareTo(Status.CONNECTED) == 0;
               if (isConnected) {


### PR DESCRIPTION
Fragments killed when the app was rotated/brought in or out of focus, were being notified of events from the server, causing the app to crash. This fixes this issue.